### PR TITLE
MRG: suggested refactoring of concat checks

### DIFF
--- a/nibabel/funcs.py
+++ b/nibabel/funcs.py
@@ -112,11 +112,10 @@ def concat_images(images, check_affines=True, axis=None):
        If True, then check that all the affines for `images` are nearly
        the same, raising a ``ValueError`` otherwise.  Default is True
     axis : None or int, optional
-        If None, concatenates on a new dimension.  This rrequires all images
+        If None, concatenates on a new dimension.  This requires all images
            to be the same shape).
         If not None, concatenates on the specified dimension.  This requires
            all images to be the same shape, except on the specified dimension.
-           For 4D images, axis must be between -2 and 3.
     Returns
     -------
     concat_img : ``SpatialImage``

--- a/nibabel/tests/test_funcs.py
+++ b/nibabel/tests/test_funcs.py
@@ -79,7 +79,6 @@ def test_concat():
                         #   but our efficient logic (where all images are
                         #   3D and the same size) fails, so we also
                         #   have to expect errors for those.
-                        expect_error = data0.ndim != data1.ndim
                         if axis is None:  # 3D from here and below
                             all_data = np.concatenate([data0[..., np.newaxis],
                                                        data1[..., np.newaxis]],

--- a/nibabel/tests/test_funcs.py
+++ b/nibabel/tests/test_funcs.py
@@ -86,6 +86,7 @@ def test_concat():
                         else:  # both 3D, appending on final axis
                             all_data = np.concatenate([data0, data1],
                                                       **np_concat_kwargs)
+                        expect_error = False
                     except ValueError:
                         # Shapes are not combinable
                         expect_error = True


### PR DESCRIPTION
This was just the result of me playing around with the logic.  I ended up
moving the `i==0` stuff outside the loop, and using your nice shape indexing
mask inside the loop.

Also some fixes as discussed in the PR.

If you prefer your version, I don't feel strongly, but here I am posting this
because I wrote it.