### PR TITLE
MRG: refactor using valid_exts

### DIFF
--- a/nibabel/analyze.py
+++ b/nibabel/analyze.py
@@ -911,7 +911,7 @@ class AnalyzeImage(SpatialImage):
     _meta_sniff_len = header_class.sizeof_hdr
     files_types = (('image', '.img'), ('header', '.hdr'))
     valid_exts = ('.img', '.hdr')
-    _compressed_exts = ('.gz', '.bz2')
+    _compressed_suffixes = ('.gz', '.bz2')
 
     makeable = True
     rw = True

--- a/nibabel/analyze.py
+++ b/nibabel/analyze.py
@@ -908,7 +908,9 @@ class AnalyzeImage(SpatialImage):
     """ Class for basic Analyze format image
     """
     header_class = AnalyzeHeader
+    _meta_sniff_len = header_class.sizeof_hdr
     files_types = (('image', '.img'), ('header', '.hdr'))
+    valid_exts = ('.img', '.hdr')
     _compressed_exts = ('.gz', '.bz2')
 
     makeable = True

--- a/nibabel/ecat.py
+++ b/nibabel/ecat.py
@@ -732,6 +732,7 @@ class EcatImage(SpatialImage):
     """
     _header = EcatHeader
     header_class = _header
+    valid_exts = ('.v',)
     _subheader = EcatSubHeader
     files_types = (('image', '.v'), ('header', '.v'))
 

--- a/nibabel/freesurfer/mghformat.py
+++ b/nibabel/freesurfer/mghformat.py
@@ -455,14 +455,12 @@ class MGHHeader(object):
 
 
 # Register .mgz extension as compressed
-ImageOpener.compress_ext_map['.mgz'] = ImageOpener.gz_def
-
-
+@ImageOpener.register_ext_from_image('.mgz', ImageOpener.gz_def)
 class MGHImage(SpatialImage):
     """ Class for MGH format image
     """
     header_class = MGHHeader
-    valid_exts = ('.mgh', '.mgz')
+    valid_exts = ('.mgh',)
     files_types = (('image', '.mgh'),)
     _compressed_suffixes = ()
 

--- a/nibabel/freesurfer/mghformat.py
+++ b/nibabel/freesurfer/mghformat.py
@@ -464,7 +464,7 @@ class MGHImage(SpatialImage):
     header_class = MGHHeader
     valid_exts = ('.mgh', '.mgz')
     files_types = (('image', '.mgh'),)
-    _compressed_exts = ()
+    _compressed_suffixes = ()
 
     makeable = True
     rw = True

--- a/nibabel/freesurfer/mghformat.py
+++ b/nibabel/freesurfer/mghformat.py
@@ -454,13 +454,17 @@ class MGHHeader(object):
         fileobj.write(ftr_nd.tostring())
 
 
-@ImageOpener.register_ext_from_image('.mgz', ImageOpener.gz_def)
+# Register .mgz extension as compressed
+ImageOpener.compress_ext_map['.mgz'] = ImageOpener.gz_def
+
+
 class MGHImage(SpatialImage):
     """ Class for MGH format image
     """
     header_class = MGHHeader
+    valid_exts = ('.mgh', '.mgz')
     files_types = (('image', '.mgh'),)
-    _compressed_exts = (('.gz',))
+    _compressed_exts = ()
 
     makeable = True
     rw = True

--- a/nibabel/freesurfer/tests/test_mghformat.py
+++ b/nibabel/freesurfer/tests/test_mghformat.py
@@ -145,7 +145,7 @@ def test_filename_exts():
     # and the default affine matrix (Note the "None")
     img = MGHImage(v, None)
     # Check if these extensions allow round trip
-    for ext in ('.mgh', '.mgz', '.mgh.gz'):
+    for ext in ('.mgh', '.mgz'):
         with InTemporaryDirectory():
             fname = 'tmpname' + ext
             save(img, fname)

--- a/nibabel/loadsave.py
+++ b/nibabel/loadsave.py
@@ -93,7 +93,7 @@ def save(img, filename):
         return
 
     # Be nice to users by making common implicit conversions
-    froot, ext, trailing = splitext_addext(filename, img._compressed_exts)
+    froot, ext, trailing = splitext_addext(filename, ('.gz', '.bz2'))
     lext = ext.lower()
 
     # Special-case Nifti singles and Pairs

--- a/nibabel/loadsave.py
+++ b/nibabel/loadsave.py
@@ -110,7 +110,7 @@ def save(img, filename):
         klass = Nifti2Image
     else:  # arbitrary conversion
         valid_klasses = [klass for klass in all_image_classes
-                         if klass.is_valid_extension(ext)]
+                         if ext in klass.valid_exts]
         if not valid_klasses:  # if list is empty
             raise ImageFileError('Cannot work out file type of "%s"' %
                                  filename)

--- a/nibabel/minc1.py
+++ b/nibabel/minc1.py
@@ -301,7 +301,7 @@ class Minc1Image(SpatialImage):
     _meta_sniff_len = 4
     valid_exts = ('.mnc',)
     files_types = (('image', '.mnc'),)
-    _compressed_exts = ('.gz', '.bz2')
+    _compressed_suffixes = ('.gz', '.bz2')
 
     makeable = True
     rw = False

--- a/nibabel/minc1.py
+++ b/nibabel/minc1.py
@@ -298,6 +298,8 @@ class Minc1Image(SpatialImage):
     load.
     '''
     header_class = Minc1Header
+    _meta_sniff_len = 4
+    valid_exts = ('.mnc',)
     files_types = (('image', '.mnc'),)
     _compressed_exts = ('.gz', '.bz2')
 

--- a/nibabel/minc2.py
+++ b/nibabel/minc2.py
@@ -152,7 +152,7 @@ class Minc2Image(Minc1Image):
     the MINC file on load.
     '''
     # MINC2 does not do compressed whole files
-    _compressed_exts = ()
+    _compressed_suffixes = ()
     header_class = Minc2Header
 
     @classmethod

--- a/nibabel/nifti1.py
+++ b/nibabel/nifti1.py
@@ -1632,6 +1632,7 @@ class Nifti1Pair(analyze.AnalyzeImage):
     """ Class for NIfTI1 format image, header pair
     """
     header_class = Nifti1PairHeader
+    _meta_sniff_len = header_class.sizeof_hdr
     rw = True
 
     def __init__(self, dataobj, affine, header=None,
@@ -1856,6 +1857,7 @@ class Nifti1Image(Nifti1Pair):
     """ Class for single file NIfTI1 format image
     """
     header_class = Nifti1Header
+    valid_exts = ('.nii',)
     files_types = (('image', '.nii'),)
 
     @staticmethod

--- a/nibabel/nifti2.py
+++ b/nibabel/nifti2.py
@@ -243,12 +243,14 @@ class Nifti2Pair(Nifti1Pair):
     """ Class for NIfTI2 format image, header pair
     """
     header_class = Nifti2PairHeader
+    _meta_sniff_len = header_class.sizeof_hdr
 
 
 class Nifti2Image(Nifti1Image):
     """ Class for single file NIfTI2 format image
     """
     header_class = Nifti2Header
+    _meta_sniff_len = header_class.sizeof_hdr
 
 
 def load(filename):

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -155,6 +155,7 @@ class ImageOpener(Opener):
     attributes, via the `register_ex_from_images`.  The class can therefore
     change state when image classes are defined.
     """
+    compress_ext_map = Opener.compress_ext_map.copy()
 
     @classmethod
     def register_ext_from_image(opener_klass, ext, func_def):

--- a/nibabel/openers.py
+++ b/nibabel/openers.py
@@ -185,6 +185,6 @@ class ImageOpener(Opener):
             assert ext not in opener_klass.compress_ext_map, \
                 "Cannot redefine extension-function mappings."
             opener_klass.compress_ext_map[ext] = func_def
-            klass.alternate_exts += (ext,)
+            klass.valid_exts += (ext,)
             return klass
         return decorate

--- a/nibabel/parrec.py
+++ b/nibabel/parrec.py
@@ -1020,6 +1020,7 @@ class PARRECHeader(Header):
 class PARRECImage(SpatialImage):
     """PAR/REC image"""
     header_class = PARRECHeader
+    valid_exts = ('.rec', '.par')
     files_types = (('image', '.rec'), ('header', '.par'))
 
     makeable = False

--- a/nibabel/spatialimages.py
+++ b/nibabel/spatialimages.py
@@ -875,6 +875,25 @@ class SpatialImage(object):
 
     @classmethod
     def _sniff_meta_for(klass, filename, sniff_nbytes):
+        """ Sniff metadata for image represented by `filename`
+
+        Parameters
+        ----------
+        filename : str
+            Filename for an image, or an image header (metadata) file.
+            If `filename` points to an image data file, and the image type has
+            a separate "header" file, we work out the name of the header file,
+            and read from that instead of `filename`.
+        sniff_nbytes : int
+            Number of bytes to read from the image or metadata file
+
+        Returns
+        -------
+        meta_bytes : None or bytes
+            None if we could not read the image or metadata file.  `meta_bytes`
+            is either length `sniff_nbytes` or the length of the image /
+            metadata file, whichever is the shorter.
+        """
         froot, ext, trailing = splitext_addext(filename,
                                                klass._compressed_suffixes)
         # Determine the metadata location, then sniff it
@@ -892,6 +911,37 @@ class SpatialImage(object):
 
     @classmethod
     def path_maybe_image(klass, filename, sniff=None, sniff_max=1024):
+        """ Return True if `filename` may be image matching this class
+
+        Parameters
+        ----------
+        filename : str
+            Filename for an image, or an image header (metadata) file.
+            If `filename` points to an image data file, and the image type has
+            a separate "header" file, we work out the name of the header file,
+            and read from that instead of `filename`.
+        sniff : None or bytes, optional
+            Bytes content read from a previous call to this method, on another
+            class.  This allows us to read metadata bytes once from the image /
+            or header, and pass this read set of bytes to other image classes,
+            therefore saving a repeat read of the metadata.  None forces this
+            method to read the metadata.
+        sniff_max : int, optional
+            The maximum number of bytes to read from the metadata.  If the
+            metadata file is long enough, we read this many bytes from the
+            file, otherwise we read to the end of the file.  Longer values
+            sniff more of the metadata / image file, making it more likely that
+            the returned sniff will be useful for later calls to
+            ``path_maybe_image`` for other image classes.
+
+        Returns
+        -------
+        maybe_image : bool
+            True if `filename` may be valid for an image of this class.
+        sniff : None or bytes
+            Read bytes content from found metadata.  May be None if the file
+            does not appear to have useful metadata.
+        """
         froot, ext, trailing = splitext_addext(filename,
                                                klass._compressed_suffixes)
         if ext.lower() not in klass.valid_exts:

--- a/nibabel/spatialimages.py
+++ b/nibabel/spatialimages.py
@@ -137,13 +137,12 @@ try:
 except NameError:  # python 3
     basestring = str
 
-import os.path
 import warnings
 
 import numpy as np
 
-from .filename_parser import types_filenames, TypesFilenamesError, \
-    splitext_addext
+from .filename_parser import (types_filenames, TypesFilenamesError,
+                              splitext_addext)
 from .fileholders import FileHolder
 from .openers import ImageOpener
 from .volumeutils import shape_zoom_affine
@@ -327,7 +326,7 @@ class SpatialImage(object):
     _meta_sniff_len = 0
     files_types = (('image', None),)
     valid_exts = ()
-    _compressed_exts = ()
+    _compressed_suffixes = ()
 
     makeable = True  # Used in test code
     rw = True  # Used in test code
@@ -753,7 +752,7 @@ class SpatialImage(object):
         try:
             filenames = types_filenames(
                 filespec, klass.files_types,
-                trailing_suffixes=klass._compressed_exts)
+                trailing_suffixes=klass._compressed_suffixes)
         except TypesFilenamesError:
             raise ImageFileError(
                 'Filespec "{0}" does not look right for class {1}'.format(
@@ -877,11 +876,12 @@ class SpatialImage(object):
     @classmethod
     def _sniff_meta_for(klass, filename, sniff_nbytes):
         froot, ext, trailing = splitext_addext(filename,
-                                               klass._compressed_exts)
+                                               klass._compressed_suffixes)
         # Determine the metadata location, then sniff it
-        t_fnames = types_filenames(filename,
-                                   klass.files_types,
-                                   trailing_suffixes=klass._compressed_exts)
+        t_fnames = types_filenames(
+            filename,
+            klass.files_types,
+            trailing_suffixes=klass._compressed_suffixes)
         meta_fname = t_fnames.get('header', filename)
         try:
             with ImageOpener(meta_fname, 'rb') as fobj:
@@ -893,7 +893,7 @@ class SpatialImage(object):
     @classmethod
     def path_maybe_image(klass, filename, sniff=None, sniff_max=1024):
         froot, ext, trailing = splitext_addext(filename,
-                                               klass._compressed_exts)
+                                               klass._compressed_suffixes)
         if ext.lower() not in klass.valid_exts:
             return False, sniff
         if not hasattr(klass.header_class, 'may_contain_header'):

--- a/nibabel/tests/test_openers.py
+++ b/nibabel/tests/test_openers.py
@@ -93,7 +93,8 @@ def test_BinOpener():
 
 
 class TestImageOpener:
-    alternate_exts = ()
+    valid_exts = ()
+
     def setUp(self):
         self.compress_ext_map = ImageOpener.compress_ext_map.copy()
 
@@ -119,7 +120,7 @@ class TestImageOpener:
         dec(self.__class__)
         assert_equal(n_associations + 1, len(ImageOpener.compress_ext_map))
         assert_true('.foo' in ImageOpener.compress_ext_map)
-        assert_true('.foo' in self.alternate_exts)
+        assert_true('.foo' in self.valid_exts)
 
         with InTemporaryDirectory():
             with ImageOpener('test.foo', 'w'):

--- a/nibabel/tests/test_openers.py
+++ b/nibabel/tests/test_openers.py
@@ -57,6 +57,7 @@ def test_Opener():
         # mode is gently ignored
         fobj = Opener(obj, mode='r')
 
+
 def test_Opener_various():
     # Check we can do all sorts of files here
     message = b"Oh what a giveaway"
@@ -84,10 +85,12 @@ def test_Opener_various():
                     # Just check there is a fileno
                     assert_not_equal(fobj.fileno(), 0)
 
+
 def test_BinOpener():
     with error_warnings():
         assert_raises(DeprecationWarning,
                       BinOpener, 'test.txt', 'r')
+
 
 class TestImageOpener:
     alternate_exts = ()
@@ -122,6 +125,9 @@ class TestImageOpener:
             with ImageOpener('test.foo', 'w'):
                 pass
             assert_true(os.path.exists('test.foo'))
+
+        # Check this doesn't add anything to parent
+        assert_false('.foo' in Opener.compress_ext_map)
 
 
 def test_file_like_wrapper():


### PR DESCRIPTION
Here I tried making these ideas explicit:

* `valid_exts` is a tuple of extensions that are valid for a particular image
  type.  This is in practice almost but not quite the same as the list of
  characteristic files for an image in `files_types`.  For example, I don't
  think the `.mat` extension should be valid for the SPM Analyze filetype, it
  is a supporting file.
* `_meta_sniff_len` is a class attribute that gives the number of bytes needed
  for a valid sniff for this image type.  For Analyze-based file types this is
  the same as the length of the header, but not for the MINC file types.
* I renamed `_compressed_exts` to `_compressed_suffixes` to make clear the
  idea that these are extra suffixes to the filename that, if present,
  indicate that the file is compressed.  For example, I don't think `.mgz` is
  a `_compressed_suffix`, but an alternative image extension.